### PR TITLE
Add empty kwargs mutation

### DIFF
--- a/lib/mutest/mutator/node/define.rb
+++ b/lib/mutest/mutator/node/define.rb
@@ -34,9 +34,16 @@ module Mutest
         # @return [undefined]
         def emit_restarg_body_mutation
           arguments.children.each do |argument|
-            next unless n_restarg?(argument) && argument.children.one?
+            replacement =
+              if n_restarg?(argument)
+                s(:array)
+              elsif n_kwrestarg?(argument)
+                s(:hash)
+              end
 
-            emit_body_prepend(s(:lvasgn, AST::Meta::Restarg.new(argument).name, s(:array)))
+            next unless replacement && argument.children.one?
+
+            emit_body_prepend(s(:lvasgn, AST::Meta::Restarg.new(argument).name, replacement))
           end
         end
 

--- a/meta/kwrestarg.rb
+++ b/meta/kwrestarg.rb
@@ -2,6 +2,7 @@ Mutest::Meta::Example.add :kwrestarg do
   source 'def foo(**bar); end'
 
   mutation 'def foo; end'
+  mutation 'def foo(**bar); bar = {}; end'
   mutation 'def foo(**_bar); end'
   mutation 'def foo(**bar); raise; end'
   mutation 'def foo(**bar); super; end'


### PR DESCRIPTION
- This is similar to the mutation we emit for restargs where we
  overwrite *args with and empty array. In this case we do the same with
  keyword rest args and assign and empty hash. This requires you to
  prove that kwargs are actually passed in and used.