### PR TITLE
Add hash hint mutation

### DIFF
--- a/config/flay.yml
+++ b/config/flay.yml
@@ -1,3 +1,3 @@
 ---
 threshold: 16
-total_score: 1309
+total_score: 1317

--- a/lib/mutest/mutator/node/arguments.rb
+++ b/lib/mutest/mutator/node/arguments.rb
@@ -13,6 +13,7 @@ module Mutest
         def dispatch
           emit_argument_presence
           emit_argument_mutations
+          emit_hash_type_hint
           emit_mlhs_expansion
         end
 
@@ -45,6 +46,22 @@ module Mutest
         # @return [Boolean]
         def invalid_argument_replacement?(mutest, index)
           n_arg?(mutest) && children[0...index].any?(&method(:n_optarg?))
+        end
+
+        def emit_hash_type_hint
+          *first_args, last_arg = children
+
+          return unless last_arg && hintworthy_node?(last_arg)
+
+          last_name = last_arg.children.first
+
+          emit_type(*first_args, s(:kwrestarg, last_name)) unless last_name.to_s.start_with?('_')
+        end
+
+        # Is this a simple arg or arg={} ?
+        def hintworthy_node?(node)
+          n_arg?(node) ||
+            (n_optarg?(node) && node.children.last.eql?(s(:hash)))
         end
 
         # Emit mlhs expansions

--- a/meta/block.rb
+++ b/meta/block.rb
@@ -19,6 +19,7 @@ Mutest::Meta::Example.add :block do
 
   singleton_mutations
   mutation 'foo'
+  mutation 'foo { |a, **b| }'
   mutation 'foo { |a, b| raise }'
   mutation 'foo { |a, _b| }'
   mutation 'foo { |_a, b| }'
@@ -32,6 +33,7 @@ Mutest::Meta::Example.add :block do
 
   singleton_mutations
   mutation 'foo { || }'
+  mutation 'foo { |(a, b), **c| }'
   mutation 'foo { |a, b, c| }'
   mutation 'foo { |(a, b), c| raise }'
   mutation 'foo { |(a), c| }'

--- a/meta/def.rb
+++ b/meta/def.rb
@@ -6,6 +6,30 @@ Mutest::Meta::Example.add :def do
 end
 
 Mutest::Meta::Example.add :def do
+  source 'def foo(a); end'
+
+  mutation 'def foo; end'
+  mutation 'def foo(_a); end'
+  mutation 'def foo(**a); end'
+  mutation 'def foo(a); raise; end'
+  mutation 'def foo(a); super; end'
+end
+
+Mutest::Meta::Example.add :def do
+  source 'def foo(a = {}); end'
+
+  mutation 'def foo; end'
+  mutation 'def foo(**a); end'
+  mutation 'def foo(_a = {}); end'
+  mutation 'def foo(a); end'
+  mutation 'def foo(a = nil); end'
+  mutation 'def foo(a = self); end'
+  mutation 'def foo(a = {}); a = {}; end'
+  mutation 'def foo(a = {}); super; end'
+  mutation 'def foo(a = {}); raise; end'
+end
+
+Mutest::Meta::Example.add :def do
   source 'def foo(a, *b); nil; end'
 
   mutation 'def foo(a, *_b); nil; end'
@@ -105,6 +129,9 @@ Mutest::Meta::Example.add :def do
 
   # Deletion of all arguments
   mutation 'def foo; end'
+
+  # Hash type hint
+  mutation 'def foo(a, **b); end'
 
   # Rename each argument
   mutation 'def foo(_a, b); end'
@@ -219,6 +246,9 @@ Mutest::Meta::Example.add :def do
 
   # Deletion of all arguments
   mutation 'def self.foo; end'
+
+  # Hash type hint
+  mutation 'def self.foo(a, **b); end'
 
   # Rename each argument
   mutation 'def self.foo(_a, b); end'


### PR DESCRIPTION
This change mutates the final `arg` or `optarg` in an `args` node to be
a `kwrestargs`. The `optarg` is only mutated when the default is `{}`.

See: https://github.com/mbj/mutant/issues/507