### PR TITLE
Fix #ignore? for nodes without a location

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,7 +35,7 @@ GIT
 PATH
   remote: .
   specs:
-    mutest (0.8.12)
+    mutest (0.0.2)
       abstract_type (~> 0.0.7)
       adamantium (~> 0.2.0)
       anima (~> 0.3.0)

--- a/config/flay.yml
+++ b/config/flay.yml
@@ -1,3 +1,3 @@
 ---
 threshold: 16
-total_score: 1325
+total_score: 1329

--- a/lib/mutest/source_file.rb
+++ b/lib/mutest/source_file.rb
@@ -22,7 +22,7 @@ module Mutest
     # TODO: Support inline comment disable
     def ignore?(node)
       location = node.location
-      return false unless location.expression
+      return false unless location && location.expression
 
       disable_lines.include?(location.line)
     end

--- a/spec/unit/mutest/source_file_spec.rb
+++ b/spec/unit/mutest/source_file_spec.rb
@@ -33,10 +33,14 @@ RSpec.describe Mutest::SourceFile do
     end
   end
 
-  it 'ignores nodes that do not have a location' do
+  it 'ignores nodes that do not have a line' do
     _, bar_method = *ast
     _, bar_method_args, = *bar_method
 
     expect(source_file.ignore?(bar_method_args)).to be(false)
+  end
+
+  it 'ignores nodes that do not have a location' do
+    expect(source_file.ignore?(s(:custom))).to be(false)
   end
 end


### PR DESCRIPTION
This is true for our custom nodes like the regexp nodes