### PR TITLE
Quick fix to make require succeed

### DIFF
--- a/lib/mutest/integration.rb
+++ b/lib/mutest/integration.rb
@@ -15,8 +15,8 @@ module Mutest
     # @param name [String]
     #
     # @return [Class<Integration>]
-    def self.setup(kernel, name)
-      kernel.require("mutest/integration/#{name}")
+    def self.setup(_kernel, name)
+      require("mutest/integration/#{name}")
       const_get(name.capitalize)
     end
 

--- a/spec/unit/mutest/cli_spec.rb
+++ b/spec/unit/mutest/cli_spec.rb
@@ -139,16 +139,9 @@ Options:
     context 'with use flag' do
       context 'when integration exists' do
         let(:flags) { %w[--use rspec] }
-
-        before do
-          expect(Kernel).to receive(:require)
-            .with('mutest/integration/rspec')
-            .and_call_original
-        end
+        let(:expected_integration) { Mutest::Integration::Rspec }
 
         it_should_behave_like 'a cli parser'
-
-        let(:expected_integration) { Mutest::Integration::Rspec }
       end
 
       context 'when integration does NOT exist' do


### PR DESCRIPTION
Makes `mutest --use rspec` work outside the bundle.