### PR TITLE
Stop mutating booleans to nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Block-pass symbol#to_proc mutations (`foo(&:to_s)` -> `foo(&:to_str)`) [[#55](https://github.com/backus/mutest/pull/55/files) ([@dgollahon][])]
 - Block-pass mutations (`foo(&method(:bar))` -> `foo(&public_method(:bar))`) [[#54](https://github.com/backus/mutest/pull/54/files) ([@dgollahon][])]
 
+### Removed
+- Boolean to `nil` mutations (`true` -> `nil`; `false` -> `nil`) [[#42](https://github.com/backus/mutest/pull/42/files) ([@dgollahon][])]
+
 ## [0.0.6] - 2017-03-04
 
 ### Fixed

--- a/config/flay.yml
+++ b/config/flay.yml
@@ -1,3 +1,3 @@
 ---
 threshold: 16
-total_score: 1330
+total_score: 1334

--- a/lib/mutest/mutator/node/literal/boolean.rb
+++ b/lib/mutest/mutator/node/literal/boolean.rb
@@ -17,7 +17,6 @@ module Mutest
           #
           # @return [undefined]
           def dispatch
-            emit_nil
             emit(s(MAP.fetch(node.type)))
           end
         end # Boolean

--- a/meta/and.rb
+++ b/meta/and.rb
@@ -5,8 +5,6 @@ Mutest::Meta::Example.add :and do
   mutation 'true'
   mutation 'false'
   mutation 'true or false'
-  mutation 'true and nil'
-  mutation 'nil and false'
   mutation 'false and false'
   mutation 'true and true'
   mutation '!true and false'

--- a/meta/array.rb
+++ b/meta/array.rb
@@ -4,7 +4,6 @@ Mutest::Meta::Example.add :array do
   singleton_mutations
   mutation 'true'
   mutation '[false]'
-  mutation '[nil]'
   mutation '[]'
 end
 
@@ -14,9 +13,7 @@ Mutest::Meta::Example.add :array do
   singleton_mutations
 
   # Mutation of each element in array
-  mutation '[nil, false]'
   mutation '[false, false]'
-  mutation '[true, nil]'
   mutation '[true, true]'
 
   # Remove each element of array once

--- a/meta/begin.rb
+++ b/meta/begin.rb
@@ -3,8 +3,6 @@ Mutest::Meta::Example.add :begin do
   # Mutation of each statement in block
   mutation 'true; true'
   mutation 'false; false'
-  mutation 'nil; false'
-  mutation 'true; nil'
 
   # Delete each statement
   mutation 'true'
@@ -14,6 +12,5 @@ end
 Mutest::Meta::Example.add :begin do
   source s(:begin, s(:true))
   # Mutation of each statement in block
-  mutation s(:begin, s(:nil))
   mutation s(:begin, s(:false))
 end

--- a/meta/block.rb
+++ b/meta/block.rb
@@ -91,7 +91,6 @@ Mutest::Meta::Example.add :block do
 
   singleton_mutations
   mutation 'foo { self << false }'
-  mutation 'foo { self << nil }'
   mutation 'foo { nil << true }'
   mutation 'foo { nil }'
   mutation 'foo { self }'

--- a/meta/break.rb
+++ b/meta/break.rb
@@ -3,6 +3,5 @@ Mutest::Meta::Example.add :break do
 
   singleton_mutations
   mutation 'break false'
-  mutation 'break nil'
   mutation 'break'
 end

--- a/meta/case.rb
+++ b/meta/case.rb
@@ -21,12 +21,6 @@ Mutest::Meta::Example.add :case do
     else
     end
   RUBY
-  mutation <<-RUBY
-    case
-    when nil
-    else
-    end
-  RUBY
 end
 
 # rubocop:disable Metrics/BlockLength

--- a/meta/casgn.rb
+++ b/meta/casgn.rb
@@ -3,7 +3,6 @@ Mutest::Meta::Example.add :casgn do
 
   mutation 'A__MUTEST__ = true'
   mutation 'A = false'
-  mutation 'A = nil'
   mutation 'remove_const :A'
 end
 
@@ -12,7 +11,6 @@ Mutest::Meta::Example.add :casgn do
 
   mutation 'self::A__MUTEST__ = true'
   mutation 'self::A = false'
-  mutation 'self::A = nil'
   mutation 'self.remove_const :A'
 end
 
@@ -22,5 +20,4 @@ Mutest::Meta::Example.add :casgn do
   singleton_mutations
   mutation 'A__MUTEST__ &&= true'
   mutation 'A &&= false'
-  mutation 'A &&= nil'
 end

--- a/meta/cvasgn.rb
+++ b/meta/cvasgn.rb
@@ -4,5 +4,4 @@ Mutest::Meta::Example.add :cvasgn do
   singleton_mutations
   mutation '@@a__mutest__ = true'
   mutation '@@a = false'
-  mutation '@@a = nil'
 end

--- a/meta/def.rb
+++ b/meta/def.rb
@@ -114,8 +114,6 @@ Mutest::Meta::Example.add :def do
   # Mutation of each statement in block
   mutation 'def foo; true; true; end'
   mutation 'def foo; false; false; end'
-  mutation 'def foo; true; nil; end'
-  mutation 'def foo; nil; false; end'
 
   # Remove statement in block
   mutation 'def foo; true; end'
@@ -161,7 +159,6 @@ Mutest::Meta::Example.add :def do
   mutation 'def foo(a, b = nil); end'
   mutation 'def foo; true; end'
   mutation 'def foo(a, b = nil); raise; end'
-  mutation 'def foo(a, b = nil); nil; end'
   mutation 'def foo(a, b = nil); false; end'
   mutation 'def foo(a); true; end'
   mutation 'def foo(a, b = nil); b = nil; true; end'
@@ -182,7 +179,6 @@ end
 Mutest::Meta::Example.add :def do
   source 'def foo(_unused = true); end'
 
-  mutation 'def foo(_unused = nil); end'
   mutation 'def foo(_unused = false); end'
   mutation 'def foo(_unused = true); raise; end'
   mutation 'def foo(_unused = true); super; end'
@@ -218,7 +214,6 @@ Mutest::Meta::Example.add :def do
   mutation 'def foo(a); end'
   mutation 'def foo(); end'
   mutation 'def foo(a = false); end'
-  mutation 'def foo(a = nil); end'
   mutation 'def foo(_a = true); end'
   mutation 'def foo(a = true); raise; end'
   mutation 'def foo(a = true); super; end'
@@ -231,8 +226,6 @@ Mutest::Meta::Example.add :def do
   # Body presence mutation
   mutation 'def self.foo; false; false; end'
   mutation 'def self.foo; true; true; end'
-  mutation 'def self.foo; true; nil; end'
-  mutation 'def self.foo; nil; false; end'
 
   # Body presence mutation
   mutation 'def self.foo; true; end'

--- a/meta/ensure.rb
+++ b/meta/ensure.rb
@@ -3,5 +3,4 @@ Mutest::Meta::Example.add :ensure do
 
   singleton_mutations
   mutation 'begin; rescue; ensure; false; end'
-  mutation 'begin; rescue; ensure; nil; end'
 end

--- a/meta/false.rb
+++ b/meta/false.rb
@@ -1,6 +1,5 @@
 Mutest::Meta::Example.add :false do
   source 'false'
 
-  mutation 'nil'
   mutation 'true'
 end

--- a/meta/gvasgn.rb
+++ b/meta/gvasgn.rb
@@ -4,5 +4,4 @@ Mutest::Meta::Example.add :gvasgn do
   singleton_mutations
   mutation '$a__mutest__ = true'
   mutation '$a = false'
-  mutation '$a = nil'
 end

--- a/meta/hash.rb
+++ b/meta/hash.rb
@@ -5,13 +5,9 @@ Mutest::Meta::Example.add :hash do
 
   # Mutation of each key and value in hash
   mutation '{ false => true  ,  false => false }'
-  mutation '{ nil   => true  ,  false => false }'
   mutation '{ true  => false ,  false => false }'
-  mutation '{ true  => nil   ,  false => false }'
   mutation '{ true  => true  ,  true  => false }'
-  mutation '{ true  => true  ,  nil   => false }'
   mutation '{ true  => true  ,  false => true  }'
-  mutation '{ true  => true  ,  false => nil   }'
 
   # Remove each key once
   mutation '{ true => true }'

--- a/meta/if.rb
+++ b/meta/if.rb
@@ -26,11 +26,9 @@ Mutest::Meta::Example.add :if do
 
   # mutation of if body
   mutation 'if condition; false; else false; end'
-  mutation 'if condition; nil;   else false; end'
 
   # mutation of else body
   mutation 'if condition; true;  else true;  end'
-  mutation 'if condition; true;  else nil;   end'
 end
 
 Mutest::Meta::Example.add :if do
@@ -39,7 +37,6 @@ Mutest::Meta::Example.add :if do
   singleton_mutations
   mutation 'if !condition; true;  end'
   mutation 'if condition;  false; end'
-  mutation 'if condition;  nil;   end'
   mutation 'if true;       true;  end'
   mutation 'if false;      true;  end'
   mutation 'if nil;        true;  end'
@@ -55,7 +52,6 @@ Mutest::Meta::Example.add :if do
   mutation 'unless true;       true;  end'
   mutation 'unless false;      true;  end'
   mutation 'unless condition;  false; end'
-  mutation 'unless condition;  nil;   end'
   mutation 'if     condition;  true;  end'
   mutation 'true'
 end
@@ -66,7 +62,6 @@ Mutest::Meta::Example.add :if do
   singleton_mutations
   mutation 'false if /foo/'
   mutation 'true if //'
-  mutation 'nil if /foo/'
   mutation 'true if true'
   mutation 'true if false'
   mutation 'true if nil'

--- a/meta/ivasgn.rb
+++ b/meta/ivasgn.rb
@@ -4,7 +4,6 @@ Mutest::Meta::Example.add :ivasgn do
   singleton_mutations
   mutation '@a__mutest__ = true'
   mutation '@a = false'
-  mutation '@a = nil'
 end
 
 Mutest::Meta::Example.add :ivasgn do

--- a/meta/kwbegin.rb
+++ b/meta/kwbegin.rb
@@ -3,5 +3,4 @@ Mutest::Meta::Example.add :kwbegin do
 
   singleton_mutations
   mutation 'begin; false; end'
-  mutation 'begin; nil; end'
 end

--- a/meta/lvasgn.rb
+++ b/meta/lvasgn.rb
@@ -4,5 +4,4 @@ Mutest::Meta::Example.add :lvasgn do
   singleton_mutations
   mutation 'a__mutest__ = true'
   mutation 'a = false'
-  mutation 'a = nil'
 end

--- a/meta/match_current_line.rb
+++ b/meta/match_current_line.rb
@@ -4,7 +4,6 @@ Mutest::Meta::Example.add :match_current_line do
   singleton_mutations
   mutation 'false if /foo/'
   mutation 'true if //'
-  mutation 'nil if /foo/'
   mutation 'true if true'
   mutation 'true if false'
   mutation 'true if nil'

--- a/meta/next.rb
+++ b/meta/next.rb
@@ -3,7 +3,6 @@ Mutest::Meta::Example.add :next do
 
   singleton_mutations
   mutation 'next false'
-  mutation 'next nil'
   mutation 'next'
   mutation 'break true'
 end

--- a/meta/or.rb
+++ b/meta/or.rb
@@ -4,9 +4,7 @@ Mutest::Meta::Example.add :or do
   singleton_mutations
   mutation 'true'
   mutation 'false'
-  mutation 'nil or false'
   mutation 'false or false'
-  mutation 'true or nil'
   mutation 'true or true'
   mutation 'true and false'
   mutation '!true or false'

--- a/meta/regexp.rb
+++ b/meta/regexp.rb
@@ -51,7 +51,6 @@ Mutest::Meta::Example.add :regexp do
 
   singleton_mutations
   mutation 'false if /foo/'
-  mutation 'nil if /foo/'
   mutation 'true if true'
   mutation 'true if false'
   mutation 'true if nil'

--- a/meta/rescue.rb
+++ b/meta/rescue.rb
@@ -6,7 +6,6 @@ Mutest::Meta::Example.add :rescue do
   mutation 'begin; rescue self, ExceptionB => error; true; end'
   mutation 'begin; rescue ExceptionA, self => error; true; end'
   mutation 'begin; rescue ExceptionA, ExceptionB => error; false; end'
-  mutation 'begin; rescue ExceptionA, ExceptionB => error; nil; end'
   mutation 'begin; true; end'
 end
 
@@ -16,7 +15,6 @@ Mutest::Meta::Example.add :rescue do
   singleton_mutations
   mutation 'begin; rescue SomeException; true; end'
   mutation 'begin; rescue SomeException => error; false; end'
-  mutation 'begin; rescue SomeException => error; nil; end'
   mutation 'begin; rescue self => error; true; end'
   mutation 'begin; true; end'
 end
@@ -26,7 +24,6 @@ Mutest::Meta::Example.add :rescue do
 
   singleton_mutations
   mutation 'begin; rescue => error; false; end'
-  mutation 'begin; rescue => error; nil; end'
   mutation 'begin; rescue; true; end'
   mutation 'begin; true; end'
 end
@@ -36,7 +33,6 @@ Mutest::Meta::Example.add :rescue do
 
   singleton_mutations
   mutation 'begin; rescue; false; end'
-  mutation 'begin; rescue; nil; end'
   mutation 'begin; true end'
 end
 
@@ -45,7 +41,6 @@ Mutest::Meta::Example.add :rescue do
 
   singleton_mutations
   mutation 'begin; false; end'
-  mutation 'begin; nil; end'
 end
 
 Mutest::Meta::Example.add :rescue do
@@ -83,5 +78,4 @@ Mutest::Meta::Example.add :rescue do
 
   singleton_mutations
   mutation 'begin; rescue; ensure; false; end'
-  mutation 'begin; rescue; ensure; nil; end'
 end

--- a/meta/send.rb
+++ b/meta/send.rb
@@ -39,7 +39,6 @@ Mutest::Meta::Example.add :send do
   mutation 'A.const_get(self, true)'
   mutation 'A.const_get(:B__mutest__, true)'
   mutation 'A.const_get(true)'
-  mutation 'A.const_get(:B, nil)'
   mutation 'A.const_get(:B, false)'
   mutation 'A.const_get(:B)'
 end
@@ -651,9 +650,7 @@ end
     mutation 'true'
     mutation 'false'
     mutation "false #{operator} false"
-    mutation "nil   #{operator} false"
     mutation "true  #{operator} true"
-    mutation "true  #{operator} nil"
   end
 end
 

--- a/meta/true.rb
+++ b/meta/true.rb
@@ -1,6 +1,5 @@
 Mutest::Meta::Example.add :true do
   source 'true'
 
-  mutation 'nil'
   mutation 'false'
 end

--- a/meta/until.rb
+++ b/meta/until.rb
@@ -6,7 +6,6 @@ Mutest::Meta::Example.add :until do
   mutation 'until true; foo; end'
   mutation 'until true; end'
   mutation 'until false; foo; bar; end'
-  mutation 'until nil; foo; bar; end'
   mutation 'until true; foo; nil; end'
   mutation 'until true; foo; self; end'
   mutation 'until true; nil; bar; end'

--- a/meta/while.rb
+++ b/meta/while.rb
@@ -8,7 +8,6 @@ Mutest::Meta::Example.add :while do
   mutation 'while true; foo; end'
   mutation 'while true; end'
   mutation 'while false; foo; bar; end'
-  mutation 'while nil;   foo; bar; end'
   mutation 'while true;  foo; nil; end'
   mutation 'while true;  nil; bar; end'
   mutation 'while true;  raise; end'
@@ -20,5 +19,4 @@ Mutest::Meta::Example.add :while do
   singleton_mutations
   mutation 'while true; raise; end'
   mutation 'while false; end'
-  mutation 'while nil; end'
 end

--- a/meta/yield.rb
+++ b/meta/yield.rb
@@ -3,6 +3,5 @@ Mutest::Meta::Example.add :yield do
 
   singleton_mutations
   mutation 'yield false'
-  mutation 'yield nil'
   mutation 'yield'
 end

--- a/spec/unit/mutest/meta/example_spec.rb
+++ b/spec/unit/mutest/meta/example_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe Mutest::Meta::Example do
     )
   end
 
-  let(:file)           { 'foo/bar.rb'         }
-  let(:node)           { s(:true)             }
-  let(:mutation_nodes) { [s(:nil), s(:false)] }
+  let(:file)           { 'foo/bar.rb' }
+  let(:node)           { s(:true)     }
+  let(:mutation_nodes) { [s(:false)]  }
 
   let(:mutations) do
     mutation_nodes.map do |node|

--- a/spec/unit/mutest/mutator/node_spec.rb
+++ b/spec/unit/mutest/mutator/node_spec.rb
@@ -20,9 +20,8 @@ RSpec.describe Mutest::Mutator::Node do
         def dispatch
           left
           emit_left(s(:nil))
-          emit_right_mutations do |node|
-            node.eql?(s(:nil))
-          end
+          emit_left_mutations
+          emit_right_mutations { false }
         end
       end
     end
@@ -32,12 +31,10 @@ RSpec.describe Mutest::Mutator::Node do
     end
 
     specify do
-      expect(apply).to eql(
-        [
-          s(:and, s(:nil), s(:true)),
-          s(:and, s(:true), s(:nil))
-        ].to_set
-      )
+      expect(apply).to eql([
+        s(:and, s(:nil),   s(:true)),
+        s(:and, s(:false), s(:true))
+      ].to_set)
     end
   end
 end


### PR DESCRIPTION
I think this mutation is probably not helpful. We generally want to
mutate to a less powerful or orthogonal alternative to the code in
place.

- We already mutate `true` to `false` and `false` to
  `true` so it seems like a change in truthiness from mutating to `nil`
  is already covered.
- `nil` would seem to be more powerful--at least on grounds of
  available methods. See below:
  * nil.methods   - false.methods # => [:to_a, :to_i, :to_f, :to_h, :to_r, :rationalize, :to_c]
  * false.methods - nil.methods   # => []
  * true.methods == false.methods # => true (so the above logic holds)

Arguably we could consider mutating from `nil` to `false` on those grounds, but I think that might cause a lot of noise / awkward places where you place a `false` but you simply mean `nothing`. That is, it'd be aggravating in the same way that being forced to write `nil` when you mean `false` in a boolean that is evaluated far away (where you can't directly assert you want your method to return false) is.

~~This PR is still a WIP. I did not resolve one unit test because I don't fully understand how it works and would have to think about it a bit more.~~ I'm opening this primarily for discussion and objections. I'd be curious if you feel differently, @backus (or anyone else).

also: this also emits fewer mutations and has a red diff. I don't think those alone are real reasons to do this, but it's a nice perk if everyone agrees this is better.