### PR TITLE
Emit restarg body mutations only when used

### DIFF
--- a/lib/mutest/mutator/node/define.rb
+++ b/lib/mutest/mutator/node/define.rb
@@ -22,8 +22,8 @@ module Mutest
         #
         # @return [undefined]
         def emit_optarg_body_assignments
-          arguments.children.each do |argument|
-            next unless n_optarg?(argument) && AST::Meta::Optarg.new(argument).used?
+          used_arguments.each do |argument|
+            next unless n_optarg?(argument)
 
             emit_body_prepend(s(:lvasgn, *argument))
           end
@@ -33,7 +33,7 @@ module Mutest
         #
         # @return [undefined]
         def emit_restarg_body_mutation
-          arguments.children.each do |argument|
+          used_arguments.each do |argument|
             replacement =
               if n_restarg?(argument)
                 s(:array)
@@ -45,6 +45,10 @@ module Mutest
 
             emit_body_prepend(s(:lvasgn, AST::Meta::Restarg.new(argument).name, replacement))
           end
+        end
+
+        def used_arguments
+          arguments.children.select { |arg| AST::Meta::Optarg.new(arg).used? }
         end
 
         # Emit valid body ASTs depending on instance body

--- a/meta/kwrestarg.rb
+++ b/meta/kwrestarg.rb
@@ -12,7 +12,6 @@ Mutest::Meta::Example.add :kwrestarg do
   source 'def foo(**_bar); end'
 
   mutation 'def foo; end'
-  mutation 'def foo(**_bar); _bar = {}; end'
   mutation 'def foo(**_bar); raise; end'
   mutation 'def foo(**_bar); super; end'
 end

--- a/meta/restarg.rb
+++ b/meta/restarg.rb
@@ -7,3 +7,11 @@ Mutest::Meta::Example.add :restarg do
   mutation 'def foo(*bar); raise; end'
   mutation 'def foo(*bar); super; end'
 end
+
+Mutest::Meta::Example.add :restarg do
+  source 'def foo(*_bar); end'
+
+  mutation 'def foo; end'
+  mutation 'def foo(*_bar); raise; end'
+  mutation 'def foo(*_bar); super; end'
+end


### PR DESCRIPTION
Currently we are emitting _bar=[] or _bar={} for *_bar and **_bar arguments,
respectively to prove that _bar is actually used. This doesn't actually make a lot of sense because the _ indicates that the argument is unused.