### PR TITLE
Fix null integraton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Master (Unreleased)]
 
+## [0.0.6] - 2017-03-04
+
 ### Fixed
 
 - Now `mutest` can REALLY be run without being in the bundle. [[#50](https://github.com/backus/mutest/pull/50/files) ([@dgollahon][])]
@@ -53,7 +55,8 @@ First proper RubyGems release
 
 <!-- Version diffs -->
 
-[Master (Unreleased)]: https://github.com/backus/mutest/compare/v0.0.5...HEAD
+[Master (Unreleased)]: https://github.com/backus/mutest/compare/v0.0.6...HEAD
+[0.0.6]: https://github.com/backus/mutest/compare/v0.0.5...v0.0.6
 [0.0.5]: https://github.com/backus/mutest/compare/v0.0.4...v0.0.5
 [0.0.4]: https://github.com/backus/mutest/compare/v0.0.3...v0.0.4
 [0.0.3]: https://github.com/backus/mutest/compare/v0.0.2...v0.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Master (Unreleased)]
 
+### Fixed
+
+- Now `mutest` can REALLY be run without being in the bundle. [[#50](https://github.com/backus/mutest/pull/50/files) ([@dgollahon][])]
+
 ## [0.0.5] - 2017-03-04
 
-### Added
+### Fixed
 
 - Now `mutest` can be run without being in the bundle. [[#46](https://github.com/backus/mutest/pull/46/files) ([@mvz][])]
 

--- a/lib/mutest/version.rb
+++ b/lib/mutest/version.rb
@@ -1,4 +1,4 @@
 module Mutest
   # Current mutest version
-  VERSION = '0.0.5'.freeze
+  VERSION = '0.0.6'.freeze
 end # Mutest

--- a/mutest.gemspec
+++ b/mutest.gemspec
@@ -13,7 +13,9 @@ Gem::Specification.new do |gem|
 
   gem.require_paths = %w[lib]
 
-  mutest_integration_files = `git ls-files -- lib/mutest/integration/*.rb`.split("\n")
+  mutest_integration_files =
+    `git ls-files -- lib/mutest/integration/*.rb`.split("\n")
+      .reject { |filename| filename =~ %r{/null.rb\z} }
 
   gem.files            = `git ls-files`.split("\n") - mutest_integration_files
   gem.test_files       = `git ls-files -- spec/{unit,integration}`.split("\n")


### PR DESCRIPTION
- The null integration was moved to a separate file in #46, but the
  .gemspec ignored it by default. I, unfortunately, already released
  the new gem before I realized the problem. This should fix it.

See: https://github.com/backus/mutest/pull/46/files#diff-fbc6907b7a6341f346df84da7d57e7c2R182