### PR TITLE
Add block pass symbol to proc mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Added
 
+- Block-pass symbol#to_proc mutations (`foo(&:to_s)` -> `foo(&:to_str)`) [[#55](https://github.com/backus/mutest/pull/55/files) ([@dgollahon][])]
 - Block-pass mutations (`foo(&method(:bar))` -> `foo(&public_method(:bar))`) [[#54](https://github.com/backus/mutest/pull/54/files) ([@dgollahon][])]
 
 ## [0.0.6] - 2017-03-04

--- a/lib/mutest/mutator/node/block_pass.rb
+++ b/lib/mutest/mutator/node/block_pass.rb
@@ -13,6 +13,15 @@ module Mutest
         # @return [undefined]
         def dispatch
           emit_arg_mutations
+          emit_symbol_to_proc_mutations
+        end
+
+        def emit_symbol_to_proc_mutations
+          return unless n_sym?(arg)
+
+          Send::SELECTOR_REPLACEMENTS.fetch(*arg, EMPTY_ARRAY).each do |method|
+            emit_arg(s(:sym, method))
+          end
         end
       end # BlockPass
     end # Node

--- a/meta/block_pass.rb
+++ b/meta/block_pass.rb
@@ -12,3 +12,24 @@ Mutest::Meta::Example.add :block_pass do
   mutation 'foo(&public_method(:bar))'
   mutation 'foo(&:bar)'
 end
+
+Mutest::Meta::Example.add :block_pass do
+  source 'foo(&:to_s)'
+
+  singleton_mutations
+  mutation 'foo'
+  mutation 'foo(&nil)'
+  mutation 'foo(&self)'
+  mutation 'foo(&:to_s__mutest__)'
+  mutation 'foo(&:to_str)'
+end
+
+Mutest::Meta::Example.add :block_pass do
+  source 'foo(&:bar)'
+
+  singleton_mutations
+  mutation 'foo'
+  mutation 'foo(&nil)'
+  mutation 'foo(&self)'
+  mutation 'foo(&:bar__mutest__)'
+end


### PR DESCRIPTION
Add symbol#to_proc mutations for block-pass node

- This performs the same method selector replacements we do with normal method calls, but for cases when the methods are called in a block-pass with a symbol.

Depends on #54.
