### PR TITLE
Add `method` method selector mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Added
 
+- Selector mutations for `[public_]method` methods (`foo.method(:to_s)` -> `foo.method(:to_str)`) [[#56](https://github.com/backus/mutest/pull/56/files) ([@dgollahon][])]
 - Block-pass symbol#to_proc mutations (`foo(&:to_s)` -> `foo(&:to_str)`) [[#55](https://github.com/backus/mutest/pull/55/files) ([@dgollahon][])]
 - Block-pass mutations (`foo(&method(:bar))` -> `foo(&public_method(:bar))`) [[#54](https://github.com/backus/mutest/pull/54/files) ([@dgollahon][])]
 

--- a/config/flay.yml
+++ b/config/flay.yml
@@ -1,3 +1,3 @@
 ---
 threshold: 16
-total_score: 1338
+total_score: 1339

--- a/lib/mutest/ast/meta/send.rb
+++ b/lib/mutest/ast/meta/send.rb
@@ -12,6 +12,7 @@ module Mutest
 
         INDEX_ASSIGNMENT_SELECTOR            = :[]=
         ATTRIBUTE_ASSIGNMENT_SELECTOR_SUFFIX = '='.freeze
+        METHOD_METHOD_SELECTORS              = %i[method public_method].freeze
 
         # Arguments of mutated node
         #
@@ -63,6 +64,11 @@ module Mutest
           return false unless receiver && n_const?(receiver)
 
           Const.new(receiver).possible_top_level?
+        end
+
+        # Test if this is a selector that returns a method object
+        def method_object_selector?
+          METHOD_METHOD_SELECTORS.include?(selector)
         end
 
         private

--- a/meta/send.rb
+++ b/meta/send.rb
@@ -878,3 +878,59 @@ Mutest::Meta::Example.add :send do
   mutation 'foo.Array(nil)'
   mutation 'foo.Array(self)'
 end
+
+Mutest::Meta::Example.add :send do
+  source 'foo.method(:to_s)'
+
+  singleton_mutations
+  mutation 'foo'
+  mutation 'foo.public_method(:to_s)'
+  mutation ':to_s'
+  mutation 'self.method(:to_s)'
+  mutation 'foo.method'
+  mutation 'foo.method(nil)'
+  mutation 'foo.method(self)'
+  mutation 'foo.method(:to_s__mutest__)'
+  mutation 'foo.method(:to_str)'
+end
+
+Mutest::Meta::Example.add :send do
+  source "foo.public_method('to_i')"
+
+  singleton_mutations
+  mutation 'foo'
+  mutation '"to_i"'
+  mutation 'self.public_method("to_i")'
+  mutation 'foo.public_method'
+  mutation 'foo.public_method(nil)'
+  mutation 'foo.public_method(self)'
+  mutation 'foo.public_method("to_int")'
+end
+
+Mutest::Meta::Example.add :send do
+  source 'foo.method(bar, baz)'
+
+  singleton_mutations
+  mutation 'foo'
+  mutation 'foo.public_method(bar, baz)'
+  mutation 'self.method(bar, baz)'
+  mutation 'foo.method'
+  mutation 'foo.method(nil, baz)'
+  mutation 'foo.method(self, baz)'
+  mutation 'foo.method(baz)'
+  mutation 'foo.method(bar, nil)'
+  mutation 'foo.method(bar, self)'
+  mutation 'foo.method(bar)'
+end
+
+Mutest::Meta::Example.add :send do
+  source "foo.bar('to_s')"
+
+  singleton_mutations
+  mutation 'foo'
+  mutation '"to_s"'
+  mutation 'self.bar("to_s")'
+  mutation 'foo.bar'
+  mutation 'foo.bar(nil)'
+  mutation 'foo.bar(self)'
+end

--- a/spec/unit/mutest/ast/meta/send_spec.rb
+++ b/spec/unit/mutest/ast/meta/send_spec.rb
@@ -5,21 +5,33 @@ RSpec.describe Mutest::AST::Meta::Send do
     Parser::CurrentRuby.parse(source)
   end
 
-  let(:method_call)            { parse('foo.bar(baz)')  }
-  let(:attribute_read)         { parse('foo.bar')       }
-  let(:index_assignment)       { parse('foo[0] = bar')  }
-  let(:attribute_assignment)   { parse('foo.bar = baz') }
-  let(:binary_method_operator) { parse('foo == bar')    }
+  let(:method_call)            { parse('foo.bar(baz)')             }
+  let(:attribute_read)         { parse('foo.bar')                  }
+  let(:index_assignment)       { parse('foo[0] = bar')             }
+  let(:attribute_assignment)   { parse('foo.bar = baz')            }
+  let(:binary_method_operator) { parse('foo == bar')               }
+  let(:method_method_call)     { parse('foo.method(:bar)')         }
+  let(:public_method_call)     { parse("foo.public_method('bar')") }
 
   class Expectation
-    include Adamantium, Anima.new(:name, :assignment, :attribute_assignment, :index_assignment, :binary_method_operator)
+    include Adamantium,
+            Anima.new(
+              :name,
+              :assignment,
+              :attribute_assignment,
+              :index_assignment,
+              :binary_method_operator,
+              :method_object_selector
+            )
 
     ALL = [
-      [:method_call,            false, false, false, false],
-      [:attribute_read,         false, false, false, false],
-      [:index_assignment,       true,  false, true,  false],
-      [:attribute_assignment,   true,  true,  false, false],
-      [:binary_method_operator, false, false, false, true]
+      [:method_call,            false, false, false, false, false],
+      [:attribute_read,         false, false, false, false, false],
+      [:index_assignment,       true,  false, true,  false, false],
+      [:attribute_assignment,   true,  true,  false, false, false],
+      [:binary_method_operator, false, false, false, true,  false],
+      [:method_method_call,     false, false, false, false, true],
+      [:public_method_call,     false, false, false, false, true]
     ].map do |values|
       new(Hash[anima.attribute_names.zip(values)])
     end.freeze


### PR DESCRIPTION
- Mutates things like `foo.method(:to_s)` to `foo.method(:to_str)`.