### PR TITLE
Add string literal mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Added
 
+- String literal mutations (`'foo'` -> `'foo__mutest__'`) [[#58](https://github.com/backus/mutest/pull/58/files) ([@dgollahon][])]
 - Selector mutations for `[public_]method` methods (`foo.method(:to_s)` -> `foo.method(:to_str)`) [[#56](https://github.com/backus/mutest/pull/56/files) ([@dgollahon][])]
 - Block-pass symbol#to_proc mutations (`foo(&:to_s)` -> `foo(&:to_str)`) [[#55](https://github.com/backus/mutest/pull/55/files) ([@dgollahon][])]
 - Block-pass mutations (`foo(&method(:bar))` -> `foo(&public_method(:bar))`) [[#54](https://github.com/backus/mutest/pull/54/files) ([@dgollahon][])]

--- a/lib/mutest/mutator/node/literal/string.rb
+++ b/lib/mutest/mutator/node/literal/string.rb
@@ -6,6 +6,8 @@ module Mutest
         class String < self
           handle(:str)
 
+          children :value
+
           private
 
           # Emit mutations
@@ -13,6 +15,7 @@ module Mutest
           # @return [undefined]
           def dispatch
             emit_singletons
+            emit_type(value + Util::Symbol::POSTFIX)
           end
         end # String
       end # Literal

--- a/lib/mutest/mutator/node/literal/symbol.rb
+++ b/lib/mutest/mutator/node/literal/symbol.rb
@@ -8,8 +8,6 @@ module Mutest
 
           children :value
 
-          PREFIX = '__mutest__'.freeze
-
           private
 
           # Emit mutations

--- a/meta/dstr.rb
+++ b/meta/dstr.rb
@@ -8,4 +8,6 @@ Mutest::Meta::Example.add :dstr do
   mutation '"foo#{bar}#{self}"'
   mutation '"foo#{nil}baz"'
   mutation '"foo#{self}baz"'
+  mutation '"foo__mutest__#{bar}baz"'
+  mutation '"foo#{bar}baz__mutest__"'
 end

--- a/meta/dsym.rb
+++ b/meta/dsym.rb
@@ -9,4 +9,6 @@ Mutest::Meta::Example.add :dsym do
   mutation ':"#{"foo"}#{self}#{"baz"}"'
   mutation ':"#{"foo"}#{bar}#{nil}"'
   mutation ':"#{"foo"}#{bar}#{self}"'
+  mutation ':"foo__mutest__#{bar}baz"'
+  mutation ':"foo#{bar}baz__mutest__"'
 end

--- a/meta/send.rb
+++ b/meta/send.rb
@@ -905,6 +905,7 @@ Mutest::Meta::Example.add :send do
   mutation 'foo.public_method(nil)'
   mutation 'foo.public_method(self)'
   mutation 'foo.public_method("to_int")'
+  mutation 'foo.public_method("to_i__mutest__")'
 end
 
 Mutest::Meta::Example.add :send do
@@ -930,6 +931,7 @@ Mutest::Meta::Example.add :send do
   mutation 'foo'
   mutation '"to_s"'
   mutation 'self.bar("to_s")'
+  mutation 'foo.bar("to_s__mutest__")'
   mutation 'foo.bar'
   mutation 'foo.bar(nil)'
   mutation 'foo.bar(self)'

--- a/meta/str.rb
+++ b/meta/str.rb
@@ -2,4 +2,5 @@ Mutest::Meta::Example.add :str do
   source '"foo"'
 
   singleton_mutations
+  mutation '"foo__mutest__"'
 end


### PR DESCRIPTION
- Mutates things like 'foo' to 'foo__mutest__'.
- This now matches what we do with symbols.
- Also removes a dead constant in the symbol mutator I noticed while implementing this.