### PR TITLE
Mutate the rhs of masgn nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Added
 
+- Right hand side mutations for multi-assignment nodes (`a, b = foo` -> `a, b = self`) [[#60](https://github.com/backus/mutest/pull/60/files) ([@dgollahon][])]
 - String literal mutations (`'foo'` -> `'foo__mutest__'`) [[#58](https://github.com/backus/mutest/pull/58/files) ([@dgollahon][])]
 - Selector mutations for `[public_]method` methods (`foo.method(:to_s)` -> `foo.method(:to_str)`) [[#56](https://github.com/backus/mutest/pull/56/files) ([@dgollahon][])]
 - Block-pass symbol#to_proc mutations (`foo(&:to_s)` -> `foo(&:to_str)`) [[#55](https://github.com/backus/mutest/pull/55/files) ([@dgollahon][])]

--- a/lib/mutest/mutator/node/masgn.rb
+++ b/lib/mutest/mutator/node/masgn.rb
@@ -14,6 +14,7 @@ module Mutest
         # @return [undefined]
         def dispatch
           emit_singletons
+          emit_right_mutations
         end
       end # MultipleAssignment
     end # Node

--- a/meta/masgn.rb
+++ b/meta/masgn.rb
@@ -2,4 +2,13 @@ Mutest::Meta::Example.add :masgn do
   source 'a, b = c, d'
 
   singleton_mutations
+  mutation 'a, b = nil'
+  mutation 'a, b = self'
+  mutation 'a, b = []'
+  mutation 'a, b = [c]'
+  mutation 'a, b = c, nil'
+  mutation 'a, b = c, self'
+  mutation 'a, b = [d]'
+  mutation 'a, b = nil, d'
+  mutation 'a, b = self, d'
 end


### PR DESCRIPTION
- Mutates things like `a,b = foo` -> `a,b = self`, etc.
- This does not complete the ideal `masgn` mutation process, but adding
  the rhs seems like a no-brainer and doesn't have any obvious gotchas
  that I can see.
- The lhs is a bit trickier and requires more thought if
  we want to avoid introducing invalid asts.