### PR TITLE
Remove unimportant changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Removed
 - Boolean to `nil` mutations (`true` -> `nil`; `false` -> `nil`) [[#42](https://github.com/backus/mutest/pull/42/files) ([@dgollahon][])]
 
-### Fixed
-- Invalid yard doc type annotations [[#51](https://github.com/backus/mutest/pull/51/files) ([@backus][])]
-
 ## [0.0.6] - 2017-03-04
 
 ### Fixed


### PR DESCRIPTION
- As @backus pointed out, these changes are really not significant to
  the public api and might be confusing to see in the changelog.