### PR TITLE
Add support for RSpec 3.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,7 +35,7 @@ GIT
 PATH
   remote: .
   specs:
-    mutest (0.0.3)
+    mutest (0.0.6)
       abstract_type (~> 0.0.7)
       adamantium (~> 0.2.0)
       anima (~> 0.3.0)
@@ -211,4 +211,4 @@ DEPENDENCIES
   rubocop-rspec (~> 1.10.0)
 
 BUNDLED WITH
-   1.14.3
+   1.15.0

--- a/mutest-rspec.gemspec
+++ b/mutest-rspec.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.extra_rdoc_files = %w[LICENSE]
 
   gem.add_runtime_dependency('mutest', "~> #{gem.version}")
-  gem.add_runtime_dependency('rspec-core', '>= 3.4.0', '< 3.6.0')
+  gem.add_runtime_dependency('rspec-core', '>= 3.4.0', '< 3.7.0')
 
   gem.add_development_dependency('bundler', '~> 1.3', '>= 1.3.5')
 end

--- a/spec/integration/mutest/rspec_spec.rb
+++ b/spec/integration/mutest/rspec_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'rspec integration', mutest: false do
   let(:base_cmd) { 'bundle exec mutest -I lib --require test_app --use rspec' }
 
-  %w[3.4 3.5].each do |version|
+  %w[3.4 3.5 3.6].each do |version|
     context "RSpec #{version}" do
       let(:gemfile) { "Gemfile.rspec#{version}" }
 

--- a/spec/integrations.yml
+++ b/spec/integrations.yml
@@ -2,7 +2,7 @@
 - name: rubyspec
   namespace: Rubyspec
   repo_uri: 'https://github.com/ruby/rubyspec.git'
-  repo_ref: 'origin/master'
+  repo_ref: 'e6665ae^' # TODO: ignore bad_syntax.rb
   mutation_coverage: false
   mutation_generation: true
   expected_errors:

--- a/test_app/Gemfile.rspec3.6
+++ b/test_app/Gemfile.rspec3.6
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+gem 'rspec',      '~> 3.6.0'
+gem 'rspec-core', '~> 3.6.0'
+gem 'mutest',       path: '../'
+gem 'mutest-rspec', path: '../'
+gem 'adamantium'
+eval_gemfile File.expand_path('../../Gemfile.shared', __FILE__)


### PR DESCRIPTION
 - Locks the rubyspec integration to a git revision that works