### PR TITLE
Revert "Mutate the rhs of masgn nodes"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Added
 
-- Right hand side mutations for multi-assignment nodes (`a, b = foo` -> `a, b = self`) [[#60](https://github.com/backus/mutest/pull/60/files) ([@dgollahon][])]
 - String literal mutations (`'foo'` -> `'foo__mutest__'`) [[#58](https://github.com/backus/mutest/pull/58/files) ([@dgollahon][])]
 - Selector mutations for `[public_]method` methods (`foo.method(:to_s)` -> `foo.method(:to_str)`) [[#56](https://github.com/backus/mutest/pull/56/files) ([@dgollahon][])]
 - Block-pass symbol#to_proc mutations (`foo(&:to_s)` -> `foo(&:to_str)`) [[#55](https://github.com/backus/mutest/pull/55/files) ([@dgollahon][])]

--- a/lib/mutest/mutator/node/masgn.rb
+++ b/lib/mutest/mutator/node/masgn.rb
@@ -14,7 +14,6 @@ module Mutest
         # @return [undefined]
         def dispatch
           emit_singletons
-          emit_right_mutations
         end
       end # MultipleAssignment
     end # Node

--- a/meta/masgn.rb
+++ b/meta/masgn.rb
@@ -2,13 +2,4 @@ Mutest::Meta::Example.add :masgn do
   source 'a, b = c, d'
 
   singleton_mutations
-  mutation 'a, b = nil'
-  mutation 'a, b = self'
-  mutation 'a, b = []'
-  mutation 'a, b = [c]'
-  mutation 'a, b = c, nil'
-  mutation 'a, b = c, self'
-  mutation 'a, b = [d]'
-  mutation 'a, b = nil, d'
-  mutation 'a, b = self, d'
 end


### PR DESCRIPTION
Reverts backus/mutest#60

So, it turns out this is actually more tricky than I anticipated. I want to come back to this, but the behavior is peculiar when a splat is involved on the RHS. Reverting for now so we can do a new release and benefit from the other changes we've made.