### PR TITLE
Add support for RSpec 3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Master (Unreleased)]
 
+## [0.0.8] - 2017-11-08
+
+### Added
+
+- Added support for RSpec 3.7 [[#88](https://github.com/backus/mutest/pull/88/files) ([@damireh][])]
+
 ## [0.0.7] - 2017-06-18
 
 ### Added
@@ -67,7 +73,8 @@ First proper RubyGems release
 
 <!-- Version diffs -->
 
-[Master (Unreleased)]: https://github.com/backus/mutest/compare/v0.0.7...HEAD
+[Master (Unreleased)]: https://github.com/backus/mutest/compare/v0.0.8...HEAD
+[0.0.8]: https://github.com/backus/mutest/compare/v0.0.7...v0.0.8
 [0.0.7]: https://github.com/backus/mutest/compare/v0.0.6...v0.0.7
 [0.0.6]: https://github.com/backus/mutest/compare/v0.0.5...v0.0.6
 [0.0.5]: https://github.com/backus/mutest/compare/v0.0.4...v0.0.5
@@ -80,3 +87,4 @@ First proper RubyGems release
 [@backus]: https://github.com/backus
 [@dgollahon]: https://github.com/dgollahon
 [@mvz]: https://github.com/mvz
+[@damireh]: https://github.com/damireh

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: .
   specs:
-    mutest (0.0.7)
+    mutest (0.0.8)
       abstract_type (~> 0.0.7)
       adamantium (~> 0.2.0)
       anima (~> 0.3.0)
@@ -137,4 +137,4 @@ DEPENDENCIES
   simplecov (~> 0.13.0)
 
 BUNDLED WITH
-   1.15.1
+   1.16.0

--- a/lib/mutest/version.rb
+++ b/lib/mutest/version.rb
@@ -1,4 +1,4 @@
 module Mutest
   # Current mutest version
-  VERSION = '0.0.7'.freeze
+  VERSION = '0.0.8'.freeze
 end # Mutest

--- a/mutest-rspec.gemspec
+++ b/mutest-rspec.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.extra_rdoc_files = %w[LICENSE]
 
   gem.add_runtime_dependency('mutest', "~> #{gem.version}")
-  gem.add_runtime_dependency('rspec-core', '>= 3.4.0', '< 3.7.0')
+  gem.add_runtime_dependency('rspec-core', '>= 3.4.0', '< 3.8.0')
 
   gem.add_development_dependency('bundler', '~> 1.3', '>= 1.3.5')
 end

--- a/spec/integration/mutest/rspec_spec.rb
+++ b/spec/integration/mutest/rspec_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'rspec integration', mutest: false do
   let(:base_cmd) { 'bundle exec mutest -I lib --require test_app --use rspec' }
 
-  %w[3.4 3.5 3.6].each do |version|
+  %w[3.4 3.5 3.6 3.7].each do |version|
     context "RSpec #{version}" do
       let(:gemfile) { "Gemfile.rspec#{version}" }
 

--- a/test_app/Gemfile.rspec3.7
+++ b/test_app/Gemfile.rspec3.7
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+gem 'rspec',      '~> 3.7.0'
+gem 'rspec-core', '~> 3.7.0'
+gem 'mutest',       path: '../'
+gem 'mutest-rspec', path: '../'
+gem 'adamantium'
+eval_gemfile File.expand_path('../../Gemfile.shared', __FILE__)


### PR DESCRIPTION
This PR updates the RSpec dependency to allow < 3.8.0